### PR TITLE
ローディングアイコンの表示が微妙におかしい問題を修正

### DIFF
--- a/src/components/Common/Loading.module.scss
+++ b/src/components/Common/Loading.module.scss
@@ -63,8 +63,8 @@
   height: 10.2em;
   background: $config-background-color;
   border-radius: 10.2em 0 0 10.2em;
-  top: -0.1em;
-  left: -0.1em;
+  top: -0.05em;
+  left: -0.05em;
   -webkit-transform-origin: 5.1em 5.1em;
   transform-origin: 5.1em 5.1em;
   -webkit-animation: load2 2s infinite ease 1.5s;
@@ -76,8 +76,8 @@
   height: 10.2em;
   background: $config-background-color;
   border-radius: 0 10.2em 10.2em 0;
-  top: -0.1em;
-  left: 4.9em;
+  top: -0.05em;
+  left: 4.95em;
   -webkit-transform-origin: 0.1em 5.1em;
   transform-origin: 0.1em 5.1em;
   -webkit-animation: load2 2s infinite ease;

--- a/src/pages/debug/index.tsx
+++ b/src/pages/debug/index.tsx
@@ -1,0 +1,8 @@
+import { NextPage } from "next";
+import Loading from "src/components/Common/Loading";
+
+const Debug: NextPage = () => {
+  return <Loading />;
+};
+
+export default Debug;


### PR DESCRIPTION
## before

![スクリーンショット 2025-03-20 23 44 57](https://github.com/user-attachments/assets/12f500de-ab6a-4f90-8549-5c2f9bf5eafb)

## after

![スクリーンショット 2025-03-20 23 43 45](https://github.com/user-attachments/assets/6e5e9624-8b67-45ad-83ba-8f42501ecdb8)

## ついで

/debug でローディングアイコンが表示できるようにした
