### PR TITLE
コンパイル時に出ていた警告の修正

### DIFF
--- a/src/components/Common/MetaHeader.tsx
+++ b/src/components/Common/MetaHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Head from "next/head";
+import Script from "next/script";
 import { GA_ID } from "src/lib/gtag";
 
 const siteName = "Testaro";
@@ -24,45 +25,43 @@ const MetaHeader: React.FC<Prop> = (prop) => {
       : defaultDescription;
   const urlResult = typeof prop.url === "string" ? `${host}${prop.url}` : host;
   return (
-    <Head>
-      <title>{titleResult}</title>
-      <meta name="description" content={descriptionResult} />
-      {/* OGPタグ https://ogp.me/#metadata */}
-      <meta property="og:type" content="website" />
-      <meta property="og:site_name" content={siteName} />
-      <meta property="og:title" content={titleResult} />
-      <meta property="og:description" content={descriptionResult} />
-      <meta property="og:image" content={imageUrl} />
-      <meta property="og:url" content={urlResult} />
-      {/* Twitterカード */}
-      <meta name="twitter:card" content="summary" />
-      <meta name="twitter:site" content="@jesus_isao" />
-      {/* その他 */}
-      <link rel="icon" href="/favicon-32x32.png" />
-      <link rel="preconnect" href="https://fonts.googleapis.com" />
-      <link rel="preconnect" href="https://fonts.gstatic.com" />
-      <link
-        href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&family=M+PLUS+Rounded+1c&display=swap"
-        rel="stylesheet"
-      />
-      <link rel="manifest" href="/manifest.json" />
+    <>
+      <Head>
+        <title>{titleResult}</title>
+        <meta name="description" content={descriptionResult} />
+        {/* OGPタグ https://ogp.me/#metadata */}
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content={siteName} />
+        <meta property="og:title" content={titleResult} />
+        <meta property="og:description" content={descriptionResult} />
+        <meta property="og:image" content={imageUrl} />
+        <meta property="og:url" content={urlResult} />
+        {/* Twitterカード */}
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:site" content="@jesus_isao" />
+        {/* その他 */}
+        <link rel="icon" href="/favicon-32x32.png" />
+        <link rel="manifest" href="/manifest.json" />
+      </Head>
       {/* Google Analytics */}
-      <script
-        async
+      <Script
+        strategy="afterInteractive"
         src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
       />
-      <script
+      <Script
+        id="gtag-init"
+        strategy="afterInteractive"
         dangerouslySetInnerHTML={{
           __html: `
-                  window.dataLayer = window.dataLayer || [];
-                  function gtag(){dataLayer.push(arguments);}
-                  gtag('js', new Date());
-                  gtag('config', '${GA_ID}', {
-                    page_path: window.location.pathname,
-                  });`,
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${GA_ID}', {
+                  page_path: window.location.pathname,
+                });`,
         }}
       />
-    </Head>
+    </>
   );
 };
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,42 @@
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+  DocumentInitialProps,
+} from "next/document";
+
+class MyDocument extends Document {
+  static async getInitialProps(
+    ctx: DocumentContext
+  ): Promise<DocumentInitialProps> {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render(): JSX.Element {
+    return (
+      <Html>
+        <Head>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&family=M+PLUS+Rounded+1c&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;


### PR DESCRIPTION
以下の修正

```
Do not add stylesheets using next/head (see <link rel="stylesheet"> tag with href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&family=M+PLUS+Rounded+1c&display=swap"). Use Document instead.
See more info here: https://nextjs.org/docs/messages/no-stylesheets-in-head-component
Do not add <script> tags using next/head (see <script> tag with src="https://www.googletagmanager.com/gtag/js?id=UA-51886701-2"). Use next/script instead.
See more info here: https://nextjs.org/docs/messages/no-script-tags-in-head-component
Do not add <script> tags using next/head (see inline <script>). Use next/script instead.
See more info here: https://nextjs.org/docs/messages/no-script-tags-in-head-component
```