### PR TITLE
ユーザーテーブルの表示カラムが少ないときに、右側に次行が回り込む不具合の修正

### DIFF
--- a/src/components/UserGenerator/UserTable.module.scss
+++ b/src/components/UserGenerator/UserTable.module.scss
@@ -10,7 +10,7 @@
 
   li {
     width: auto;
-    display: inline-flex;
+    display: flex;
 
     input {
       border-radius: 0;

--- a/src/components/UserGenerator/UserTable.tsx
+++ b/src/components/UserGenerator/UserTable.tsx
@@ -40,13 +40,16 @@ const generateHeaderRow = (
   for (const key of sortedUserKeys) {
     if (!displayColumns[key]) continue;
     items.push(
-      <div
+      <span
         className={style.headerCell}
-        style={{ width: userDisplayInfo[key]["width"] }}
+        style={{
+          minWidth: userDisplayInfo[key]["width"],
+          maxWidth: userDisplayInfo[key]["width"],
+        }}
         key={`header_${key}`}
       >
         {headerLabels[key] || key}
-      </div>
+      </span>
     );
   }
   return (
@@ -66,7 +69,10 @@ const generateUserRow = (
     if (!displayColumns[key]) continue;
     items.push(
       <input
-        style={{ width: userDisplayInfo[key]["width"] }}
+        style={{
+          minWidth: userDisplayInfo[key]["width"],
+          maxWidth: userDisplayInfo[key]["width"],
+        }}
         readOnly
         key={key}
         type="text"


### PR DESCRIPTION
# 不具合

![スクリーンショット 2025-03-23 12 46 30](https://github.com/user-attachments/assets/65659068-2680-46d2-9653-bc9c6df205d7)

# 修正後

![スクリーンショット 2025-03-23 13 01 11](https://github.com/user-attachments/assets/3ef534bf-11c5-44ff-b20b-b7404ed9b7e5)
